### PR TITLE
Correct service name for centos 7 - Issue #3

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,8 +29,9 @@ class nfs::params {
   }
 
   $service = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => 'nfs-kernel-server',
-    default                   => 'nfs',
+    /(?i:Debian|Ubuntu|Mint)/       => 'nfs-kernel-server',
+    /(?i:RedHat|Centos|Scientific)/ => 'nfs-server',
+    default                         => 'nfs',
   }
 
   $service_status = $::operatingsystem ? {


### PR DESCRIPTION
In centos 7, nfs service name is nfs-server. I correct it. Add an regex to params.pp, as it was requested in issue 3.

https://github.com/example42/puppet-nfs/issues/3