### PR TITLE
Fixed mount commands by adding a pretty generic path

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
     "firewall": "git://github.com/example42/puppet-firewall.git"
     "iptables": "git://github.com/example42/puppet-iptables.git"
     "concat": "git://github.com/puppetlabs/puppet-concat.git"
-    "stdlib": "git://github.com/puppetlabs/stdlib.git"
+    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     "nfs": "#{source_dir}"
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -32,6 +32,7 @@ define nfs::mount(
       exec {"create ${real_mountpoint} and parents":
         command => "mkdir -p ${real_mountpoint}",
         unless  => "test -d ${real_mountpoint}",
+        path    => "/bin:/usr/bin:/usr/local/bin"
       }
       Mount["shared ${share} by ${server}"] {
         require => [Exec["create ${real_mountpoint} and parents"], Class['nfs::client']],


### PR DESCRIPTION
This is a fix for #8. I tested this on centos 6. It should be compatible will all linux distros and mac osx