### PR TITLE
Adding nfs::export resource to manage /etc/exports file …

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ For detailed info about the logic and usage patterns of Example42 modules check 
 'client_options' is a passthrough to the [mount type options attribute] (https://docs.puppetlabs.com/references/latest/type.html#mount-attribute-options).
 If the mountpoint directory does not exist it will be created along with any parent directories that don't exist, essentially 'mkdir -p $mountpoint'.
 
+* Exporting NFS shares (server only)
+
+        nfs::export { '/var/log':
+          hosts => [{                 # Hosts must be wrapped in [] even if it is a single entry
+            'host' => '*',            # Host can be '*', IP, IP w/ netmask, or hostname
+            'options' => 'ro,fsid=0'  # Host specific nfs options
+          },
+          order => 10                 # Optional, order to arrange export entries. Defaults to 100
+        }]
+
+* Another example with multiple access control entries
+
+        nfs::export { '/opt/tomcat/webapps':
+          hosts => [
+            {
+              'host' => 'host.example.com',
+              'options' => 'rw'
+            },
+            {
+              'host' => '192.168.56.0/24',
+              'options' => 'rw,sync'
+            },
+            {
+              'host' => '*',
+              'options' => 'ro,fsid=0'
+            }
+          ]
+        }
 
 ## USAGE - Overrides and Customizations
 * Use custom sources for main config file 

--- a/README.rdoc
+++ b/README.rdoc
@@ -64,6 +64,34 @@ For detailed info about the logic and usage patterns of Example42 modules check 
 'client_options' is a passthrough to the {mount type options attribute}[https://docs.puppetlabs.com/references/latest/type.html#mount-attribute-options].
 If the mountpoint directory does not exist it will be created along with any parent directories that don't exist, essentially 'mkdir -p $mountpoint'.
 
+* Exporting NFS shares (server only)
+
+        nfs::export { '/var/log':
+          hosts => [{                 # Hosts must be wrapped in [] even if it is a single entry
+            'host' => '*',            # Host can be '*', IP, IP w/ netmask, or hostname
+            'options' => 'ro,fsid=0'  # Host specific nfs options
+          },
+          order => 10                 # Optional, order to arrange export entries. Defaults to 100
+        }]
+
+* Another example with multiple access control entries
+
+        nfs::export { '/opt/tomcat/webapps':
+          hosts => [
+            {
+              'host' => 'host.example.com',
+              'options' => 'rw'
+            },
+            {
+              'host' => '192.168.56.0/24',
+              'options' => 'rw,sync'
+            },
+            {
+              'host' => '*',
+              'options' => 'ro,fsid=0'
+            }
+          ]
+        }
 
 == USAGE - Overrides and Customizations
 * Use custom sources for main config file 

--- a/manifests/export.pp
+++ b/manifests/export.pp
@@ -1,0 +1,27 @@
+# This resource manages an individual export rule in /etc/exports
+define nfs::export(
+  $mount_point = $name,
+  $hosts,
+  $order       = '100',
+) {
+  include nfs
+  include nfs::params
+
+  if $nfs::manage_file == false {
+    warn('nfs::manage_config_file has been disabled. This resource is now unused!')
+  } else {
+    validate_absolute_path($mount_point)
+    validate_array($hosts)
+    # FIXME: Add validation of hash values for host and options
+    # host: one of '*', IP, IP w/ netmask, or a hostname
+    # options: any of 'ro','rw','sync',wdelay...
+    validate_numeric($order)
+
+    # Create an exports fragment
+    concat::fragment { "nfs_cfg_${name}":
+      target  => $nfs::config_file,
+      content => template($nfs::template),
+      order   => $order,
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -242,6 +242,7 @@ class nfs (
   $config_file_owner   = params_lookup( 'config_file_owner' ),
   $config_file_group   = params_lookup( 'config_file_group' ),
   $config_file_init    = params_lookup( 'config_file_init' ),
+  $manage_config_file  = params_lookup( 'manage_config_file' ),
   $pid_file            = params_lookup( 'pid_file' ),
   $data_dir            = params_lookup( 'data_dir' ),
   $log_dir             = params_lookup( 'log_dir' ),
@@ -325,11 +326,6 @@ class nfs (
   $manage_file_source = $nfs::source ? {
     ''        => undef,
     default   => $nfs::source,
-  }
-
-  $manage_file_content = $nfs::template ? {
-    ''        => undef,
-    default   => template($nfs::template),
   }
 
   include nfs::client

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,7 +100,8 @@ class nfs::params {
   $source = ''
   $source_dir = ''
   $source_dir_purge = false
-  $template = ''
+  $manage_config_file = true
+  $template = 'nfs/export.erb'
   $options = ''
   $service_autorestart = true
   $version = 'present'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -23,19 +23,20 @@ class nfs::server {
     noop      => $nfs::noops,
   }
 
-  file { 'nfs.conf':
-    ensure  => $nfs::manage_file,
-    path    => $nfs::config_file,
-    mode    => $nfs::config_file_mode,
-    owner   => $nfs::config_file_owner,
-    group   => $nfs::config_file_group,
-    require => Package[$nfs::package],
-    notify  => $nfs::manage_service_autorestart,
-    source  => $nfs::manage_file_source,
-    content => $nfs::manage_file_content,
-    replace => $nfs::manage_file_replace,
-    audit   => $nfs::manage_audit,
-    noop    => $nfs::noops,
+  if $nfs::manage_config_file {
+    concat { $nfs::config_file:
+      ensure  => $nfs::manage_file,
+      mode    => $nfs::config_file_mode,
+      owner   => $nfs::config_file_owner,
+      group   => $nfs::config_file_group,
+      require => Package[$nfs::package],
+      notify  => $nfs::manage_service_autorestart,
+      warn    => true,
+      order   => numeric,
+      replace => $nfs::manage_file_replace,
+      audit   => $nfs::manage_audit,
+      noop    => $nfs::noops,
+    }
   }
 
   # The whole nfs configuration directory can be recursively overriden

--- a/templates/export.erb
+++ b/templates/export.erb
@@ -1,0 +1,1 @@
+<%= "#{mount_point}" %><% hosts.each { |host| %><%= " #{host['host']}" %><% unless host['options'].nil? || host['options'].empty? %><%= "(#{host['options']})" %><% end %><% } %>


### PR DESCRIPTION
This is still a work in progress, but I wanted to start the conversation as to if this is something you are ok with including in this module. The other modules I have seen all use filebucketing and I wanted one that I could manage with a defined resource type. This would allow me to define individual shares in multiple profiles that are pulled together into a role without conflicting with each other. Please let me know what you think of this and how I am trying to implement it.