### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,6 +121,6 @@ class nfs::params {
   $puppi_helper = 'standard'
   $debug = false
   $audit_only = false
-  $noops = undef
+  $noops = false
 
 }


### PR DESCRIPTION
With parser = future this error is thrown:

`Parameter noop failed on Package[nfs-common]: Invalid value "". Valid values are true, false.`

`undef` is normally handled as false in eg. `if statements` with puppet. Is there a particular reason why you set the default to undef?
`noop` [must be true or false](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)

Please create a new version on puppetlabs.
