### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,7 +134,7 @@
 # [*noops*]
 #   Set noop metaparameter to true for all the resources managed by the module.
 #   Basically you can run a dryrun for this specific module if you set
-#   this to true. Default: undef
+#   this to true. Default: false
 #
 # Default class params - As defined in nfs::params.
 # Note that these variables are mostly defined and used in the module itself,


### PR DESCRIPTION
With parser = future this error is thrown:

` Parameter noop failed on Package[nfs-common]: Invalid value "". Valid values are true, false.`

`undef` is normally handled as false in eg. `if statements` with puppet. Is there a particular reason why you set the default to undef?
`noop` [must be true or false](https://docs.puppetlabs.com/puppet/latest/reference/metaparameter.html#noop)

Please create a new version on puppetlabs.
