### PR TITLE
remove noop

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ For detailed info about the logic and usage patterns of Example42 modules check 
           audit_only => true
         }
 
-* Module dry-run: Do not make any change on *all* the resources provided by the module
-
-        class { 'nfs':
-          noops => true
-        }
-
 * Mounting NFS shares
 
         nfs::mount { '/mnt/bigdata':

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -8,7 +8,6 @@ class nfs::client {
 
   package { $nfs::package:
     ensure => $nfs::manage_package,
-    noop   => $nfs::noops,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,11 +131,6 @@
 #   Can be defined also by the (top scope) variables $nfs_audit_only
 #   and $audit_only
 #
-# [*noops*]
-#   Set noop metaparameter to true for all the resources managed by the module.
-#   Basically you can run a dryrun for this specific module if you set
-#   this to true. Default: undef
-#
 # Default class params - As defined in nfs::params.
 # Note that these variables are mostly defined and used in the module itself,
 # overriding the default values might not affected all the involved components.
@@ -229,7 +224,6 @@ class nfs (
   $firewall_dst        = params_lookup( 'firewall_dst' , 'global' ),
   $debug               = params_lookup( 'debug' , 'global' ),
   $audit_only          = params_lookup( 'audit_only' , 'global' ),
-  $noops               = params_lookup( 'noops' ),
   $package             = params_lookup( 'package' ),
   $service             = params_lookup( 'service' ),
   $service_status      = params_lookup( 'service_status' ),
@@ -351,7 +345,6 @@ class nfs (
       ensure    => $nfs::manage_file,
       variables => $classvars,
       helper    => $nfs::puppi_helper,
-      noop      => $nfs::noops,
     }
   }
 
@@ -370,7 +363,6 @@ class nfs (
       owner   => 'root',
       group   => 'root',
       content => inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*|.*psk.*|.*key)/ }.to_yaml %>'),
-      noop    => $nfs::noops,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,6 +121,5 @@ class nfs::params {
   $puppi_helper = 'standard'
   $debug = false
   $audit_only = false
-  $noops = undef
 
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,7 +9,6 @@ class nfs::server {
   if $nfs::package_server != '' {
     package { $nfs::package_server:
       ensure => $nfs::manage_package,
-      noop   => $nfs::noops,
     }
   }
 
@@ -20,7 +19,6 @@ class nfs::server {
     hasstatus => $nfs::service_status,
     pattern   => $nfs::process,
     require   => Package[$nfs::package],
-    noop      => $nfs::noops,
   }
 
   file { 'nfs.conf':
@@ -35,7 +33,6 @@ class nfs::server {
     content => $nfs::manage_file_content,
     replace => $nfs::manage_file_replace,
     audit   => $nfs::manage_audit,
-    noop    => $nfs::noops,
   }
 
   # The whole nfs configuration directory can be recursively overriden
@@ -52,7 +49,6 @@ class nfs::server {
       force   => $nfs::bool_source_dir_purge,
       replace => $nfs::manage_file_replace,
       audit   => $nfs::manage_audit,
-      noop    => $nfs::noops,
     }
   }
 
@@ -66,7 +62,6 @@ class nfs::server {
         target   => $nfs::monitor_target,
         tool     => $nfs::monitor_tool,
         enable   => $nfs::manage_monitor,
-        noop     => $nfs::noops,
       }
     }
     if $nfs::service != '' {
@@ -78,7 +73,6 @@ class nfs::server {
         argument => $nfs::process_args,
         tool     => $nfs::monitor_tool,
         enable   => $nfs::manage_monitor,
-        noop     => $nfs::noops,
       }
     }
   }
@@ -95,7 +89,6 @@ class nfs::server {
       direction   => 'input',
       tool        => $nfs::firewall_tool,
       enable      => $nfs::manage_firewall,
-      noop        => $nfs::noops,
     }
   }
 

--- a/spec/classes/standard42_spec.rb
+++ b/spec/classes/standard42_spec.rb
@@ -59,17 +59,6 @@ describe 'nfs' do
     it { should contain_firewall('nfs_tcp_42').with_enable('true') }
   end
 
-  describe 'Test noops mode' do
-    let(:params) { {:noops => true, :monitor => true , :firewall => true, :port => '42', :protocol => 'tcp'} }
-    it { should contain_package('nfs-utils').with_noop('true') }
-    it { should contain_service('nfs').with_noop('true') }
-    it { should contain_file('nfs.conf').with_noop('true') }
-    it { should contain_monitor__process('nfs_process').with_noop('true') }
-    it { should contain_monitor__process('nfs_process').with_noop('true') }
-    it { should contain_monitor__port('nfs_tcp_42').with_noop('true') }
-    it { should contain_firewall('nfs_tcp_42').with_noop('true') }
-  end
-
   describe 'Test customizations - template' do
     let(:params) { {:template => "nfs/spec.erb" , :options => { 'opt_a' => 'value_a' } } }
     it 'should generate a valid template' do


### PR DESCRIPTION
Removed because maintained recommended it.

> It was a bad idea, and setting it to false would have unwanted behaviour when puppet is run with --noop . 